### PR TITLE
Feat/fix turn logic

### DIFF
--- a/main.c
+++ b/main.c
@@ -66,6 +66,7 @@ int main(void)
 
     int wasMousePressed = 0;
     Ficha *selected = NULL;
+    Ficha *candidate = NULL;
 
 
     while (!WindowShouldClose())    // Detect window close button or ESC key
@@ -76,7 +77,7 @@ int main(void)
         DibujarFichas(Negras, BLACK);
         DibujarFichas(Blancas, WHITE);
 
-        /*if(turno == 0)
+        if(turno == 0)
         {
             if(selected)
             {
@@ -86,23 +87,23 @@ int main(void)
                 {
                     // aqui posiblemente queremos revisar si el siguiente click del usuario es
                     // en un movimiento legal? si lo es, realizarlo, si no lo es, "limpiar" la seleccion con selected=null
-                    PosDiagonalNegras(GetMouseX(), GetMouseY(), selected);
-                    selected = NULL;
+                    if(PosDiagonalNegras(GetMouseX(), GetMouseY(), selected))
+                    {
+                      turno = 1;
+                      selected = NULL;
+                    }
                 }
                     //else
                     //selected = NULL;
                     //cambioDeTurno(&turno);
-            }
-
-            if( selected == NULL && IsMouseButtonDown(MOUSE_BUTTON_LEFT))
+            } else if( selected == NULL && IsMouseButtonDown(MOUSE_BUTTON_LEFT))
             {
                 selected = DetectF(GetMouseX(), GetMouseY(), Negras);
                 if(selected == NULL)
                     DrawText("eres un burro", 200,400,36,RED);
             }
-        }*/
-
-        if(turno == 1)
+        }
+        else if(turno == 1)
         {
             if(selected)
             {
@@ -112,17 +113,18 @@ int main(void)
                 {
                     // aqui posiblemente queremos revisar si el siguiente click del usuario es
                     // en un movimiento legal? si lo es, realizarlo, si no lo es, "limpiar" la seleccion con selected=null
-                    PosDiagonalBlancas(GetMouseX(), GetMouseY(), selected);
-                    selected = NULL;
-
-                    //else
+                    if(PosDiagonalBlancas(GetMouseX(), GetMouseY(), selected))
+                    {
+                      // asumo que este movimiento YA fue legal
+                      turno = 0;
+                      selected = NULL;
+                    }
+                  //else
                         //selected = NULL;
                     //cambioDeTurno(&turno);
                 }
 
-            }
-
-            if( selected == NULL && IsMouseButtonDown(MOUSE_BUTTON_LEFT))
+            } else if( selected == NULL && IsMouseButtonDown(MOUSE_BUTTON_LEFT))
             {
                 selected = DetectF(GetMouseX(), GetMouseY(), Blancas);
                 if(selected == NULL)

--- a/settings.c
+++ b/settings.c
@@ -327,6 +327,8 @@ int PosDiagonalBlancas(int x, int y, Ficha* ficha)
         {
             MovimientoBlancas(ficha, derecha); //Movimiento de fichas blancas a la derecha
             return 1;
+        } else {
+          return 0;
         }
     }
     if (x > ficha->x - 145 && ficha->x - 55 > x)
@@ -335,10 +337,10 @@ int PosDiagonalBlancas(int x, int y, Ficha* ficha)
         {
             MovimientoBlancas(ficha, izquierda); //Movimiento de fichas blancas a la izquierda
             return 1;
+        } else {
+          return 0;
         }
     }
     else
         return 0;
-
-
 }

--- a/settings.c
+++ b/settings.c
@@ -304,14 +304,12 @@ int PosDiagonalNegras(int x, int y, Ficha* ficha)
     }
     if (x > ficha->x - 145 && ficha->x - 55 > x)
     {
-        if (y < ficha->y + 145 && ficha->y + 55 < y)
-        {
-            MovimientoNegras(ficha, izquierda); //Movimiento de fichas negras a la izquierda
-            return 1;
+        if (y < ficha->y + 145 && ficha->y + 55 < y) {
+          MovimientoNegras(ficha, izquierda); //Movimiento de fichas negras a la izquierda
+          return 1;
         }
     }
-    else
-        return 0;
+    return 0;
 }
 
 int PosDiagonalBlancas(int x, int y, Ficha* ficha)
@@ -323,24 +321,17 @@ int PosDiagonalBlancas(int x, int y, Ficha* ficha)
 
     if (x < ficha->x + 145 && ficha->x + 55 < x)
     {
-        if (y > ficha->y - 145 && ficha->y - 55 > y)
-        {
-            MovimientoBlancas(ficha, derecha); //Movimiento de fichas blancas a la derecha
-            return 1;
-        } else {
-          return 0;
+        if (y > ficha->y - 145 && ficha->y - 55 > y) {
+          MovimientoBlancas(ficha, derecha); //Movimiento de fichas blancas a la derecha
+          return 1;
         }
     }
     if (x > ficha->x - 145 && ficha->x - 55 > x)
     {
-        if (y > ficha->y - 145 && ficha->y - 55 > y)
-        {
-            MovimientoBlancas(ficha, izquierda); //Movimiento de fichas blancas a la izquierda
-            return 1;
-        } else {
-          return 0;
+        if (y > ficha->y - 145 && ficha->y - 55 > y) {
+          MovimientoBlancas(ficha, izquierda); //Movimiento de fichas blancas a la izquierda
+          return 1;
         }
     }
-    else
-        return 0;
+    return 0;
 }


### PR DESCRIPTION
Unos cuantos errores: 

- En el ciclo principal de juego despues de realizar un movimiento valido y cambiar el turno se intentaba recuperar la seleccion del jugador que acababa de jugar. (Ya se arregló, los turnos se intercambian de forma válida)
- En la rutina para revisar si un movimiento es legal o no se generó un bug donde no se regresaba 0 para ciertos movimientos ilegales (i.e entraba al primer if, pero el segundo if no era válido y la funcion no terminaba correctamente" 
- LEAN LOS WARNINGS QUE OCURREN AL COMPILAR

![image](https://user-images.githubusercontent.com/8302464/143892003-1b57a949-8d54-4fed-af59-3320d5613b83.png)

eso significa que Clion detecto que ciertas funciones terminan sin regresar un valor no es sorprendente que ambas funciones correspondan a las que nos causaban el bug principal. 
